### PR TITLE
[fix] input limit

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
         border-radius: 5px;
         font-family: Courier New, monospace;
         font-size: 14px;
-        width: 50px;
+        width: 120px;
     }
 </style>
 </head>
@@ -79,9 +79,9 @@
 <font face="Courier New"><h1 id="timer">05:00.000</h1></font>
 
 <div id="modifyContainer">
-    <input type="number" id="minuteInput" placeholder="分钟">
-    <input type="number" id="secondInput" placeholder="秒">
-    <input type="number" id="millisecondInput" placeholder="毫秒">
+    <input type="number" id="minuteInput" placeholder="分钟（默认 5）">
+    <input type="number" id="secondInput" placeholder="秒（默认 0）">
+    <input type="number" id="millisecondInput" placeholder="毫秒（默认 0）">
     <button id="modifyButton" onclick="modifyTimer()">保存</button>
 </div>
 
@@ -92,7 +92,7 @@
 <button id="stopButton" onclick="stop()" disabled="">停止计时</button>
 <h3>Initial Version by CodingOIer (<a href="mailto:wanghongtiancodingoier@outlook.com"><font color="#71c9ce">wanghongtiancodingoier@outlook.com</font></a>)</h3>
 <h3>Modified & Enhanced by nr0728 (<a href="mailto:oier0728@gmail.com"><font color="#71c9ce">oier0728@gmail.com</font></a>)</h3>
-<h3>欢迎访问 <a href="https://github.com/CodingOIer/5-Timer"><font color="#71c9ce">GitHub 仓库</font></a></h3>
+<h3>欢迎访问 <a href="https://github.com/nr0728/timer"><font color="#71c9ce">GitHub 仓库</font></a></h3>
 
 
 <script>
@@ -122,9 +122,15 @@ function init()
 
 function modifyTimer()
 {
-    let nmin=parseInt(document.getElementById('minuteInput').value);
-    let nsecond=parseInt(document.getElementById('secondInput').value);
-    let nmillisecond=parseInt(document.getElementById('millisecondInput').value);
+    let nmin=document.getElementById('minuteInput').value;
+    let nsecond=document.getElementById('secondInput').value;
+    let nmillisecond=document.getElementById('millisecondInput').value;
+    if(nmin=="") {nmin="5";}
+    if(nsecond=="") {nsecond="0";}
+    if(nmillisecond=="") {nmillisecond="0";}
+    nmin=parseInt(nmin);
+    nsecond=parseInt(nsecond);
+    nmillisecond=parseInt(nmillisecond);
     if(nmin<0||nmin>99)
     {
         alert('分钟数只能介于 0 和 99 之间！');
@@ -132,12 +138,12 @@ function modifyTimer()
     }
     if(nsecond<0||nsecond>59)
     {
-        alert('分钟数只能介于 0 和 59 之间！');
+        alert('秒数只能介于 0 和 59 之间！');
         return;
     }
     if(nmillisecond<0||nmillisecond>999)
     {
-        alert('分钟数只能介于 0 和 999 之间！');
+        alert('毫秒数只能介于 0 和 999 之间！');
         return;
     }
     min=nmin;


### PR DESCRIPTION
fix typo: '秒/毫秒' is wrongly typed as '分钟'
fix bug: check if input is empty & add default value